### PR TITLE
fix: handle `repo.maven.apache.org` when no version is known #16

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -232,7 +232,7 @@ export const REPO_TYPES: RepoType[] = [
         dataSource: DATA_SOURCES.NEXUSIQ,
         appendVersionPath: '',
         pathRegex:
-            /^(?<groupArtifactId>([^#?&]*)+)\/(?<version>[^/#&?]+)\/?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?/,
+            /^(?<groupArtifactId>([^#?&]*)+)\/(?<version>[^/#&?]+)?\/?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?/,
     },
     {
         url: 'https://search.maven.org/artifact/',


### PR DESCRIPTION
Fix to resolve #16.