### PR TITLE
fix: page annotation for npmjs.org change due to page html updates

### DIFF
--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -220,7 +220,7 @@ export const REPO_TYPES: RepoType[] = [
         url: 'https://www.npmjs.com/package/',
         repoFormat: FORMATS.npm,
         repoID: REPOS.npmJs,
-        titleSelector: '#top > div > h2 > span',
+        titleSelector: '#top > div > h1 > span',
         versionPath: '{url}/{packagename}/v/{versionNumber}',
         appendVersionPath: '/v/{versionNumber}',
         pathRegex:


### PR DESCRIPTION
Fix for #98 

Before:
![Screenshot 2023-10-12 at 08 57 28](https://github.com/sonatype-nexus-community/sonatype-platform-browser-extension/assets/10280392/68c46bb5-5661-483b-82a9-4981e581e9e5)

After:
<img width="1366" alt="Screenshot 2023-10-12 at 09 03 01" src="https://github.com/sonatype-nexus-community/sonatype-platform-browser-extension/assets/10280392/f59ef896-56f3-4f9a-aad2-1540d8c70f25">
