### PR TITLE
feat: automatically prompt user for updated credentials if they become invalid during use

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -219,6 +219,10 @@
         "message": "Provide your username and token for your Sonatype IQ Server. Then connect to retrieve the list of available applications.",
         "description": "Second point of configuration for Sonatype IQ Server"
     },
+    "OPTIONS_EXISTING_CREDENTIALS_INVALID": {
+        "message": "Your existing credentials are invalid - please update them",
+        "description": "If during use the configured credentials become invalid, this message is used to ask the user to update their credentials."
+    },
     "OPTIONS_PAGE_SONATYPE_BUTTON_CONNECT_IQ": {
         "message": "Connect",
         "description": "Button text for 'Connect' button"

--- a/src/components/Options/IQServer/IQServerOptionsPage.tsx
+++ b/src/components/Options/IQServer/IQServerOptionsPage.tsx
@@ -60,6 +60,7 @@ const _browser: any = chrome ? chrome : browser
 export interface IqServerOptionsPageInterface {
     setExtensionConfig: (settings: ExtensionConfiguration) => void
     install: boolean
+    invalidCredentials: boolean
 }
 
 export default function IQServerOptionsPage(props: IqServerOptionsPageInterface) {
@@ -406,6 +407,11 @@ export default function IQServerOptionsPage(props: IqServerOptionsPageInterface)
                                     <p className='nx-p'>
                                         <strong>2)</strong> {_browser.i18n.getMessage('OPTIONS_PAGE_SONATYPE_POINT_2')}
                                     </p>
+                                    {props.invalidCredentials === true && iqAuthenticated !== true && (
+                                        <NxStatefulErrorAlert>
+                                            Your credentials are invalid - please update them
+                                        </NxStatefulErrorAlert>
+                                    )}
                                     <div className='nx-form-row'>
                                         <NxFormGroup label={_browser.i18n.getMessage('LABEL_USERNAME')} isRequired>
                                             <NxStatefulTextInput

--- a/src/components/Options/Options.tsx
+++ b/src/components/Options/Options.tsx
@@ -46,6 +46,7 @@ enum OPTIONS_PAGE_MODE {
 export default function Options() {
     const [extensionConfig, setExtensionConfig] = useState<ExtensionConfiguration>(DEFAULT_EXTENSION_SETTINGS)
     const search = window.location.search
+    const fragment = window.location.hash
     const params = new URLSearchParams(search)
     let pageMode: OPTIONS_PAGE_MODE = OPTIONS_PAGE_MODE.SONATYPE
 
@@ -56,6 +57,7 @@ export default function Options() {
     }
 
     const install = params.has('install')
+    const invalidCredentials = fragment === '#invalid-credentials'
 
     useMemo(
         () =>
@@ -146,7 +148,11 @@ export default function Options() {
                     <GeneralOptionsPage setExtensionConfig={handleNewExtensionConfig} />
                 )}
                 {pageMode === OPTIONS_PAGE_MODE.SONATYPE && (
-                    <IQServerOptionsPage install={install} setExtensionConfig={handleNewExtensionConfig} />
+                    <IQServerOptionsPage
+                        install={install}
+                        invalidCredentials={invalidCredentials}
+                        setExtensionConfig={handleNewExtensionConfig}
+                    />
                 )}
             </ExtensionConfigurationContext.Provider>
         </React.StrictMode>

--- a/src/error/ExtensionError.ts
+++ b/src/error/ExtensionError.ts
@@ -24,6 +24,13 @@ export class ExtensionError extends Error {
 }
 
 /**
+ * Base class for general connectivity errors with Sonatype IQ Server.
+ * 
+ * These may be specialised in later releases.
+ */
+export class GeneralConnectivityError extends ExtensionError {}
+
+/**
  * Error thrown when configuration of the extension is invalid.
  *
  * For example - attempting to access IQ configuration when data source is set to OSS INDEX.
@@ -37,3 +44,9 @@ export class InvalidConfigurationError extends ExtensionError {}
  * For example - attempting to access IQ configuration when data source is set to OSS INDEX.
  */
 export class IncompleteConfigurationError extends ExtensionError {}
+
+/**
+ * Error thrown when the configured credentials are invalid.
+ *
+ */
+export class UserAuthenticationError extends ExtensionError {}


### PR DESCRIPTION
Resolves #102.

This PR adds logic to detect 401 (Un-authorized) responses from Sonatype IQ Server and will open the extensions Options Page with a notice prompting the user to update their credentials (currently in English only).

<img width="1814" alt="Screenshot 2023-10-13 at 08 39 29" src="https://github.com/sonatype-nexus-community/sonatype-platform-browser-extension/assets/10280392/e41d054a-9464-4073-b5a6-631a89b2b90c">
