### PR TITLE
feat: handle navigation to selected versions of components

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In all cases, Sonatype IQ Server versions 150 and newer have been confirmed as s
 
 _Notes:_
 
-1. See issue [#237](https://github.com/sonatype-nexus-community/nexus-iq-chrome-extension/issues/237)
+1. See issue [#110](https://github.com/sonatype-nexus-community/sonatype-platform-browser-extension/issues/110)
 2. See issue [#130](https://github.com/sonatype-nexus-community/nexus-iq-chrome-extension/issues/130)
 3. Run on a public instance of jFrog Artifactory - support coming soon
 4. Where the Public Registry maintains pages for all versions, navigation to specific versions can be supported

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ In all cases, Sonatype IQ Server versions 150 and newer have been confirmed as s
 | CocoaPods              | Swift / Objective-C | ✅      | `https://cocoapods.org/`         | ❌                              |
 | Conan IO               | C / C++             | ✅      | `https://conan.io/center/`       | ✅                              |
 | CRAN                   | R                   | ✅      | `https://cran.r-project.org`     | ❌                              |
-| Crates.io              | Rust                | ❌ ^1   | `https://crates.io/`             | ✅                              |
+| Crates.io              | Rust                | ❌ ^1   | `https://crates.io/`             | N/A                             |
 | Go.dev                 | Go                  | ❌ ^2   | `https://pkg.go.dev/`            | N/A                             |
 | Maven Central          | Java                | ✅      | `https://central.sonatype.com/`  | ✅                              |
 | Maven Central (simple) | Java                | ✅      | `https://repo.maven.apache.org/` | ❌                              |

--- a/README.md
+++ b/README.md
@@ -50,32 +50,33 @@ In all cases, Sonatype IQ Server versions 150 and newer have been confirmed as s
 
 ### Public Registries
 
-| Registry               | Language            | Enabled | URL                              | Sonatype Lifecycle |
-| ---------------------- | ------------------- | ------- | -------------------------------- | ------------------ |
-| Alpine Linux           | Alpine Linux        | ✅      | `https://pkgs.alpinelinux.org/`  | ✅                 |
-| Clojars                | Java                | ❌      | `https://clojars.org/`           | ✅                 |
-| CocoaPods              | Swift / Objective-C | ✅      | `https://cocoapods.org/`         | ✅                 |
-| Conan IO               | C / C++             | ✅      | `https://conan.io/center/`       | ✅                 |
-| CRAN                   | R                   | ✅      | `https://cran.r-project.org`     | ✅                 |
-| Crates.io              | Rust                | ❌ ^1   | `https://crates.io/`             | ✅                 |
-| Go.dev                 | Go                  | ❌ ^2   | `https://pkg.go.dev/`            | ✅                 |
-| Maven Central          | Java                | ✅      | `https://central.sonatype.com/`  | ✅                 |
-| Maven Central (simple) | Java                | ✅      | `https://repo.maven.apache.org/` | ✅                 |
-| Maven Central (simple) | Java                | ✅      | `https://repo1.maven.org/`       | ✅                 |
-| Maven Central (old)    | Java                | ✅      | `https://search.maven.org/`      | ✅                 |
-| MVN Repository         | Java                | ✅      | `https://mvnrepository.com/`     | ✅                 |
-| NPM JS                 | Javascript          | ✅      | `https://www.npmjs.com/`         | ✅                 |
-| NuGet Gallery          | .NET                | ✅      | `https://www.nuget.org/`         | ✅                 |
-| Packagist              | PHP                 | ✅      | `https://packagist.org/`         | ✅                 |
-| PyPI                   | Python              | ✅      | `https://pypi.org/`              | ✅                 |
-| RubGems                | Ruby                | ✅      | `https://rubygems.org/`          | ✅                 |
-| Spring.io              | Java                | ❌ ^3   | `https://repo.spring.io/list/`   | ✅                 |
+| Registry               | Language            | Enabled | URL                              | Component Version Navigation ^4 |
+| ---------------------- | ------------------- | ------- | -------------------------------- | ------------------------------- |
+| Alpine Linux           | Alpine Linux        | ✅      | `https://pkgs.alpinelinux.org/`  | ❌                              |
+| Clojars                | Java                | ❌      | `https://clojars.org/`           | N/A                             |
+| CocoaPods              | Swift / Objective-C | ✅      | `https://cocoapods.org/`         | ❌                              |
+| Conan IO               | C / C++             | ✅      | `https://conan.io/center/`       | ✅                              |
+| CRAN                   | R                   | ✅      | `https://cran.r-project.org`     | ❌                              |
+| Crates.io              | Rust                | ❌ ^1   | `https://crates.io/`             | ✅                              |
+| Go.dev                 | Go                  | ❌ ^2   | `https://pkg.go.dev/`            | N/A                             |
+| Maven Central          | Java                | ✅      | `https://central.sonatype.com/`  | ✅                              |
+| Maven Central (simple) | Java                | ✅      | `https://repo.maven.apache.org/` | ❌                              |
+| Maven Central (simple) | Java                | ✅      | `https://repo1.maven.org/`       | ❌                              |
+| Maven Central (old)    | Java                | ✅      | `https://search.maven.org/`      | ✅                              |
+| MVN Repository         | Java                | ✅      | `https://mvnrepository.com/`     | ✅                              |
+| NPM JS                 | Javascript          | ✅      | `https://www.npmjs.com/`         | ✅                              |
+| NuGet Gallery          | .NET                | ✅      | `https://www.nuget.org/`         | ✅                              |
+| Packagist              | PHP                 | ✅      | `https://packagist.org/`         | ✅                              |
+| PyPI                   | Python              | ✅      | `https://pypi.org/`              | ✅                              |
+| RubGems                | Ruby                | ✅      | `https://rubygems.org/`          | ✅                              |
+| Spring.io              | Java                | ❌ ^3   | `https://repo.spring.io/list/`   | N/A                             |
 
 _Notes:_
 
 1. See issue [#237](https://github.com/sonatype-nexus-community/nexus-iq-chrome-extension/issues/237)
 2. See issue [#130](https://github.com/sonatype-nexus-community/nexus-iq-chrome-extension/issues/130)
 3. Run on a public instance of jFrog Artifactory - support coming soon
+4. Where the Public Registry maintains pages for all versions, navigation to specific versions can be supported
 
 ### Private Hosted Registries
 
@@ -193,6 +194,9 @@ When you acess the Sonatype Platform Browser Extension, you'll be shown the info
 Accessing the "Remediation" tab will provide easy access to recommended versions along with a timeline of all known versions and how they stack up against your organisations policies in your Sonatype IQ Server.
 
 ![Remediation Information](./docs/images/extension-open-02.png)
+
+For Open Source Registries that support navigation to specific versions, you can click on the Remediation or Version to have your browser navigate to that version easily.
+See [this table](#public-registries) to see which Registries we have support for this.
 
 ### Policy Violation(s)
 

--- a/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
@@ -180,6 +180,7 @@ function IqAllVersionDetails() {
                             key={version.component?.packageUrl}
                             selected={versionPurl.version == currentPurl?.version}>
                             <NxList.Text
+                                // @todo : Only allow click if the RepoType defines supportsVersionNavigation === true
                                 onClick={() =>
                                     getNewSelectedVersionUrl(
                                         new URL(popupContext.currentTab?.url as string),

--- a/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
@@ -185,85 +185,158 @@ function IqAllVersionDetails() {
                     )
                     const clickable: boolean = versionUrl.toString() !== currentUrl.toString()
 
-                    return (
-                        <NxList.ButtonItem
-                            key={version.component?.packageUrl}
-                            selected={versionPurl.version == currentPurl?.version}>
-                            <NxList.Text
-                                {...(clickable && {
-                                    onClick: () => {
-                                        _browser.tabs.update({
-                                            url: versionUrl.toString(),
-                                        })
-                                    },
-                                })}
-                                ref={currentPurl?.version == versionPurl.version ? currentVersionRef : null}>
-                                <NxGrid.Row
-                                    style={{
-                                        marginTop: '0px',
-                                        marginBottom: '0px',
-                                    }}>
-                                    <NxGrid.Column className='nx-grid-col-50'>
-                                        <NxGrid.Header>
-                                            <NxPolicyViolationIndicator
-                                                style={{ marginBottom: '16px !important' }}
-                                                policyThreatLevel={
-                                                    Math.round(
-                                                        getMaxViolation(
-                                                            version.policyData as ApiComponentPolicyViolationListDTOV2
-                                                        )
-                                                    ) as ThreatLevelNumber
-                                                }>
-                                                {versionPurl.version}
-                                            </NxPolicyViolationIndicator>
-
-                                            <Tooltip title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
-                                                <span className='nx-pull-right'>
-                                                    {catalogDateDifference(version.catalogDate)}
-                                                </span>
-                                            </Tooltip>
-                                        </NxGrid.Header>
-                                        {version.policyData != undefined && (
-                                            <React.Fragment>
-                                                <GetPolicyViolationsIndicator
-                                                    policyData={version.policyData}
-                                                    policyType={'Security'}
-                                                />
-                                                <GetPolicyViolationsIndicator
-                                                    policyData={version.policyData}
-                                                    policyType={'License'}
-                                                />
-                                                <GetPolicyViolationsIndicator
-                                                    policyData={version.policyData}
-                                                    policyType={'Architecture'}
-                                                />
-                                                <GetPolicyViolationsIndicator
-                                                    policyData={version.policyData}
-                                                    policyType={'Other'}
-                                                />
-                                            </React.Fragment>
-                                        )}
-                                    </NxGrid.Column>
-                                    {version.relativePopularity !== undefined && (
+                    if (clickable) {
+                        return (
+                            <NxList.ButtonItem
+                                key={version.component?.packageUrl}
+                                selected={versionPurl.version == currentPurl?.version}>
+                                <NxList.Text
+                                    {...(clickable && {
+                                        onClick: () => {
+                                            _browser.tabs.update({
+                                                url: versionUrl.toString(),
+                                            })
+                                        },
+                                    })}
+                                    ref={currentPurl?.version == versionPurl.version ? currentVersionRef : null}>
+                                    <NxGrid.Row
+                                        style={{
+                                            marginTop: '0px',
+                                            marginBottom: '0px',
+                                        }}>
                                         <NxGrid.Column className='nx-grid-col-50'>
-                                            <Tooltip title={`Popularity: ${version.relativePopularity}`}>
-                                                <div>
-                                                    <NxMeter
-                                                        value={version.relativePopularity as number}
-                                                        max={100}
-                                                        children={''}
-                                                        style={{
-                                                            color: 'rgb(139, 199, 62) !important',
-                                                        }}
+                                            <NxGrid.Header>
+                                                <NxPolicyViolationIndicator
+                                                    style={{ marginBottom: '16px !important' }}
+                                                    policyThreatLevel={
+                                                        Math.round(
+                                                            getMaxViolation(
+                                                                version.policyData as ApiComponentPolicyViolationListDTOV2
+                                                            )
+                                                        ) as ThreatLevelNumber
+                                                    }>
+                                                    {versionPurl.version}
+                                                </NxPolicyViolationIndicator>
+
+                                                <Tooltip title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
+                                                    <span className='nx-pull-right'>
+                                                        {catalogDateDifference(version.catalogDate)}
+                                                    </span>
+                                                </Tooltip>
+                                            </NxGrid.Header>
+                                            {version.policyData != undefined && (
+                                                <React.Fragment>
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'Security'}
                                                     />
-                                                </div>
-                                            </Tooltip>
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'License'}
+                                                    />
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'Architecture'}
+                                                    />
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'Other'}
+                                                    />
+                                                </React.Fragment>
+                                            )}
                                         </NxGrid.Column>
-                                    )}
-                                </NxGrid.Row>
-                            </NxList.Text>
-                        </NxList.ButtonItem>
-                    )
+                                        {version.relativePopularity !== undefined && (
+                                            <NxGrid.Column className='nx-grid-col-50'>
+                                                <Tooltip title={`Popularity: ${version.relativePopularity}`}>
+                                                    <div>
+                                                        <NxMeter
+                                                            value={version.relativePopularity as number}
+                                                            max={100}
+                                                            children={''}
+                                                            style={{
+                                                                color: 'rgb(139, 199, 62) !important',
+                                                            }}
+                                                        />
+                                                    </div>
+                                                </Tooltip>
+                                            </NxGrid.Column>
+                                        )}
+                                    </NxGrid.Row>
+                                </NxList.Text>
+                            </NxList.ButtonItem>
+                        )
+                    } else {
+                        return (
+                            <NxList.Item key={version.component?.packageUrl}>
+                                <NxList.Text
+                                    ref={currentPurl?.version == versionPurl.version ? currentVersionRef : null}>
+                                    <NxGrid.Row
+                                        style={{
+                                            marginTop: '0px',
+                                            marginBottom: '0px',
+                                        }}>
+                                        <NxGrid.Column className='nx-grid-col-50'>
+                                            <NxGrid.Header>
+                                                <NxPolicyViolationIndicator
+                                                    style={{ marginBottom: '16px !important' }}
+                                                    policyThreatLevel={
+                                                        Math.round(
+                                                            getMaxViolation(
+                                                                version.policyData as ApiComponentPolicyViolationListDTOV2
+                                                            )
+                                                        ) as ThreatLevelNumber
+                                                    }>
+                                                    {versionPurl.version}
+                                                </NxPolicyViolationIndicator>
+
+                                                <Tooltip title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
+                                                    <span className='nx-pull-right'>
+                                                        {catalogDateDifference(version.catalogDate)}
+                                                    </span>
+                                                </Tooltip>
+                                            </NxGrid.Header>
+                                            {version.policyData != undefined && (
+                                                <React.Fragment>
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'Security'}
+                                                    />
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'License'}
+                                                    />
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'Architecture'}
+                                                    />
+                                                    <GetPolicyViolationsIndicator
+                                                        policyData={version.policyData}
+                                                        policyType={'Other'}
+                                                    />
+                                                </React.Fragment>
+                                            )}
+                                        </NxGrid.Column>
+                                        {version.relativePopularity !== undefined && (
+                                            <NxGrid.Column className='nx-grid-col-50'>
+                                                <Tooltip title={`Popularity: ${version.relativePopularity}`}>
+                                                    <div>
+                                                        <NxMeter
+                                                            value={version.relativePopularity as number}
+                                                            max={100}
+                                                            children={''}
+                                                            style={{
+                                                                color: 'rgb(139, 199, 62) !important',
+                                                            }}
+                                                        />
+                                                    </div>
+                                                </Tooltip>
+                                            </NxGrid.Column>
+                                        )}
+                                    </NxGrid.Row>
+                                </NxList.Text>
+                            </NxList.Item>
+                        )
+                    }
                 })}
             </NxList>
         )

--- a/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
@@ -29,7 +29,7 @@ import { ExtensionConfigurationContext } from '../../../../../../context/Extensi
 import './AllVersionsDetails.css'
 import { DATA_SOURCE } from '../../../../../../utils/Constants'
 import { ApiComponentPolicyViolationListDTOV2, ApiPolicyViolationDTOV2 } from '@sonatype/nexus-iq-api-client'
-import { getNewUrlandGo } from '../../../../../../utils/Helpers'
+import { getNewSelectedVersionUrl } from '../../../../../../utils/Helpers'
 import { Tooltip } from '@material-ui/core'
 import { getMaxThreatLevelForPolicyViolations } from '../../../../../../types/Component'
 
@@ -79,27 +79,28 @@ function IqAllVersionDetails() {
         const differenceInMinutes = differenceInSeconds / 60
         const differenceInHours = Math.round(differenceInMinutes / 60)
         const differenceInDays = Math.round(differenceInHours / 24)
-        const differenceInMonths = (endDate.getMonth() - startDate.getMonth()) + (12 * (endDate.getFullYear() - startDate.getFullYear()))
+        const differenceInMonths =
+            endDate.getMonth() - startDate.getMonth() + 12 * (endDate.getFullYear() - startDate.getFullYear())
         const differenceInWeeks = Math.round(differenceInDays / 7)
-        
+
         let yearsDiff = endDate.getFullYear() - startDate.getFullYear()
 
         if (
             endDate.getMonth() < startDate.getMonth() ||
             (endDate.getMonth() === startDate.getMonth() && endDate.getDate() < startDate.getDate())
-          ) {
+        ) {
             yearsDiff -= 1
-          }
-      
+        }
+
         const difference = {
-          milliseconds: differenceInMilliseconds,
-          seconds: differenceInSeconds,
-          minutes: differenceInMinutes,
-          hours: differenceInHours,
-          days: differenceInDays,
-          months: differenceInMonths,
-          weeks: differenceInWeeks,
-          years: yearsDiff,
+            milliseconds: differenceInMilliseconds,
+            seconds: differenceInSeconds,
+            minutes: differenceInMinutes,
+            hours: differenceInHours,
+            days: differenceInDays,
+            months: differenceInMonths,
+            weeks: differenceInWeeks,
+            years: yearsDiff,
         }
 
         if (difference.years !== undefined && difference.years > 0) {
@@ -108,27 +109,27 @@ function IqAllVersionDetails() {
                 const remainingMonths = 12 - startDate.getMonth() - 1
                 const monthString = `${remainingMonths} mo${remainingMonths !== 1 ? 's' : ''}`
                 return `${yearString} ${monthString}`
-              }
+            }
             return yearString
-          } else if (difference.months !== undefined && difference.months > 0) {
+        } else if (difference.months !== undefined && difference.months > 0) {
             return `${difference.months} mo${difference.months !== 1 ? 's' : ''}`
-          } else if (difference.weeks !== undefined && difference.weeks >= 1 ) {
+        } else if (difference.weeks !== undefined && difference.weeks >= 1) {
             return `${difference.weeks} wk${difference.weeks !== 1 ? 's' : ''}`
-          } else if (difference.days !== undefined && difference.days >= 2) {
+        } else if (difference.days !== undefined && difference.days >= 2) {
             return `${difference.days} day${difference.days !== 1 ? 's' : ''}`
-          } else if (difference.hours !== undefined && difference.hours > 0) {
+        } else if (difference.hours !== undefined && difference.hours > 0) {
             return `${difference.hours} hr${difference.hours !== 1 ? 's' : ''}`
-          } else if (difference.minutes !== undefined && difference.minutes > 0) {
+        } else if (difference.minutes !== undefined && difference.minutes > 0) {
             return `${difference.minutes} min${difference.minutes !== 1 ? 's' : ''}`
-          } else {
+        } else {
             return `${difference.seconds} sec${difference.seconds !== 1 ? 's' : ''}`
-          }
-      }
+        }
+    }
 
     function GetPolicyViolationsIndicator({ policyData, policyType }) {
         let filteredPolicies: ApiPolicyViolationDTOV2[] | undefined = []
         const policyTypes = ['Security', 'License', 'Architecture']
-    
+
         if (policyType === 'All Policies') {
             filteredPolicies = policyData.policyViolations
         } else if (policyType === 'Other') {
@@ -138,34 +139,32 @@ function IqAllVersionDetails() {
         } else {
             filteredPolicies = policyData.policyViolations?.filter((policy) => policy.policyName?.includes(policyType))
         }
-    
+
         const policyTypeLabel = policyType === 'Architecture' ? 'Quality' : policyType
-    
+
         if (filteredPolicies !== undefined && filteredPolicies.length > 0) {
             const maxPolicyThreatLevel = Math.round(
                 getMaxThreatLevelForPolicyViolations(filteredPolicies)
             ) as ThreatLevelNumber
             return (
                 <React.Fragment>
-                <Tooltip
-                    arrow
-                    title={`The highest ${policyTypeLabel} policy threat level: ${maxPolicyThreatLevel}`}>
+                    <Tooltip
+                        arrow
+                        title={`The highest ${policyTypeLabel} policy threat level: ${maxPolicyThreatLevel}`}>
                         <span>
-                    <NxThreatIndicator policyThreatLevel={maxPolicyThreatLevel}/>
-                    </span>
+                            <NxThreatIndicator policyThreatLevel={maxPolicyThreatLevel} />
+                        </span>
                     </Tooltip>
-                    
                 </React.Fragment>
             )
         }
         return (
             <React.Fragment>
-                <Tooltip
-                    arrow
-                    title={`No ${policyTypeLabel} policy violations`}>
-                        <span>
-                <NxThreatIndicator />
-                </span></Tooltip>
+                <Tooltip arrow title={`No ${policyTypeLabel} policy violations`}>
+                    <span>
+                        <NxThreatIndicator />
+                    </span>
+                </Tooltip>
             </React.Fragment>
         )
     }
@@ -182,10 +181,10 @@ function IqAllVersionDetails() {
                             selected={versionPurl.version == currentPurl?.version}>
                             <NxList.Text
                                 onClick={() =>
-                                    getNewUrlandGo(
-                                        popupContext.currentTab,
-                                        currentPurl?.version as string,
-                                        versionPurl.version as string
+                                    getNewSelectedVersionUrl(
+                                        new URL(popupContext.currentTab?.url as string),
+                                        popupContext.currentPurl as PackageURL,
+                                        versionPurl.version as string | undefined
                                     )
                                 }
                                 ref={currentPurl?.version == versionPurl.version ? currentVersionRef : null}>
@@ -198,20 +197,22 @@ function IqAllVersionDetails() {
                                         <NxGrid.Header>
                                             {/* <strong>{versionPurl.version}</strong> */}
                                             <NxPolicyViolationIndicator
-                                                    style={{ marginBottom: '16px !important' }}
-                                                    policyThreatLevel={
-                                                        Math.round(
-                                                            getMaxViolation(version.policyData as ApiComponentPolicyViolationListDTOV2)
-                                                        ) as ThreatLevelNumber
-                                                    }>
-                                                    {versionPurl.version}
-                                                </NxPolicyViolationIndicator>
+                                                style={{ marginBottom: '16px !important' }}
+                                                policyThreatLevel={
+                                                    Math.round(
+                                                        getMaxViolation(
+                                                            version.policyData as ApiComponentPolicyViolationListDTOV2
+                                                        )
+                                                    ) as ThreatLevelNumber
+                                                }>
+                                                {versionPurl.version}
+                                            </NxPolicyViolationIndicator>
 
-                                            <Tooltip
-                                                title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
+                                            <Tooltip title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
                                                 {/* <span className='nx-pull-right'>{calculateAge(version.catalogDate)} Yrs</span> */}
-                                                <span className='nx-pull-right'>{catalogDateDifference(version.catalogDate)}</span>
-                                                
+                                                <span className='nx-pull-right'>
+                                                    {catalogDateDifference(version.catalogDate)}
+                                                </span>
                                             </Tooltip>
                                         </NxGrid.Header>
                                         {version.policyData != undefined && (
@@ -238,16 +239,16 @@ function IqAllVersionDetails() {
                                     {version.relativePopularity !== undefined && (
                                         <NxGrid.Column className='nx-grid-col-50'>
                                             <Tooltip title={`Popularity: ${version.relativePopularity}`}>
-                                            <div>
-                                                <NxMeter
-                                                    value={version.relativePopularity as number}
-                                                    max={100}
-                                                    children={''}
-                                                    style={{
-                                                        color: 'rgb(139, 199, 62) !important',
-                                                    }}
-                                                />
-                                              </div>
+                                                <div>
+                                                    <NxMeter
+                                                        value={version.relativePopularity as number}
+                                                        max={100}
+                                                        children={''}
+                                                        style={{
+                                                            color: 'rgb(139, 199, 62) !important',
+                                                        }}
+                                                    />
+                                                </div>
                                             </Tooltip>
                                         </NxGrid.Column>
                                     )}

--- a/src/components/Popup/IQServer/RemediationPage/RemediationDetails/RemediationDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/RemediationDetails/RemediationDetails.tsx
@@ -43,27 +43,46 @@ function IqRemediationDetails() {
                     const clickable: boolean = versionUrl.toString() !== currentUrl.toString()
 
                     if (change !== undefined) {
-                        return (
-                            <NxList.LinkItem
-                                href='#'
-                                key={`${change}-${id}`}
-                                {...(clickable && {
-                                    onClick: () => {
-                                        _browser.tabs.update({
-                                            url: versionUrl.toString(),
-                                        })
-                                    },
-                                })}>
-                                <NxList.Text>
-                                    <small>{REMEDIATION_LABELS[change.type as string]}</small>
-                                </NxList.Text>
-                                <NxList.Subtext>
-                                    <strong>
-                                        {change.data?.component?.componentIdentifier?.coordinates ? version : 'UNKNOWN'}
-                                    </strong>
-                                </NxList.Subtext>
-                            </NxList.LinkItem>
-                        )
+                        if (clickable) {
+                            return (
+                                <NxList.LinkItem
+                                    href='#'
+                                    key={`${change}-${id}`}
+                                    {...(clickable && {
+                                        onClick: () => {
+                                            _browser.tabs.update({
+                                                url: versionUrl.toString(),
+                                            })
+                                        },
+                                    })}>
+                                    <NxList.Text>
+                                        <small>{REMEDIATION_LABELS[change.type as string]}</small>
+                                    </NxList.Text>
+                                    <NxList.Subtext>
+                                        <strong>
+                                            {change.data?.component?.componentIdentifier?.coordinates
+                                                ? version
+                                                : 'UNKNOWN'}
+                                        </strong>
+                                    </NxList.Subtext>
+                                </NxList.LinkItem>
+                            )
+                        } else {
+                            return (
+                                <NxList.Item key={`${change}-${id}`}>
+                                    <NxList.Text>
+                                        <small>{REMEDIATION_LABELS[change.type as string]}</small>
+                                    </NxList.Text>
+                                    <NxList.Subtext>
+                                        <strong>
+                                            {change.data?.component?.componentIdentifier?.coordinates
+                                                ? version
+                                                : 'UNKNOWN'}
+                                        </strong>
+                                    </NxList.Subtext>
+                                </NxList.Item>
+                            )
+                        }
                     }
                 })}
             </NxList>

--- a/src/components/Popup/IQServer/RemediationPage/RemediationDetails/RemediationDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/RemediationDetails/RemediationDetails.tsx
@@ -36,6 +36,7 @@ function IqRemediationDetails() {
                             <NxList.LinkItem
                                 href='#'
                                 key={`${change}-${id}`}
+                                // @todo : Only allow click if the RepoType defines supportsVersionNavigation === true
                                 onClick={() =>
                                     getNewSelectedVersionUrl(
                                         new URL(popupContext.currentTab?.url as string),

--- a/src/components/Popup/IQServer/RemediationPage/RemediationDetails/RemediationDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/RemediationDetails/RemediationDetails.tsx
@@ -19,12 +19,12 @@ import { ExtensionPopupContext } from '../../../../../context/ExtensionPopupCont
 import { ExtensionConfigurationContext } from '../../../../../context/ExtensionConfigurationContext'
 import { DATA_SOURCE, REMEDIATION_LABELS } from '../../../../../utils/Constants'
 import './RemediationDetails.css'
-import { getNewUrlandGo } from '../../../../../utils/Helpers'
+import { getNewSelectedVersionUrl } from '../../../../../utils/Helpers'
+import { PackageURL } from 'packageurl-js'
 
 function IqRemediationDetails() {
     const popupContext = useContext(ExtensionPopupContext)
     const versionChanges = popupContext.iq?.remediationDetails?.remediation?.versionChanges
-    const currentPurlVersion: string = popupContext.currentPurl?.version as string
 
     return (
         <React.Fragment>
@@ -36,7 +36,13 @@ function IqRemediationDetails() {
                             <NxList.LinkItem
                                 href='#'
                                 key={`${change}-${id}`}
-                                onClick={() => getNewUrlandGo(popupContext.currentTab, currentPurlVersion, version)}>
+                                onClick={() =>
+                                    getNewSelectedVersionUrl(
+                                        new URL(popupContext.currentTab?.url as string),
+                                        popupContext.currentPurl as PackageURL,
+                                        version
+                                    )
+                                }>
                                 <NxList.Text>
                                     <small>{REMEDIATION_LABELS[change.type as string]}</small>
                                 </NxList.Text>

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -21,11 +21,6 @@ export enum DATA_SOURCE {
     OSSINDEX = 'Sonatype OSS Index',
 }
 
-export const REPOSITORY_MANAGERS = {
-    NEXUS: 'nexus',
-    ARTIFACTORY: 'artifactory',
-}
-
 export const REMEDIATION_LABELS = {
     'next-no-violations': 'Next version with no policy violation(s)',
     'next-non-failing': 'Next version with no policy action failure(s)',
@@ -87,9 +82,7 @@ export interface RepoType {
     repoFormat: string          // Repo Format
     repoID: string              // Unique ID for this Repo
     titleSelector: string       // DOM selector to find the Package Title - used to annotate the page
-    // versionSelector?: string
     versionPath: string         // URL format with placeholders
-    // appendVersionPath?: string
     pathRegex: RegExp           // Regex for parsing URL
     versionDomPath: string      // DOM selector to find component version on the page (not always in the URL)
     supportsVersionNavigation: boolean // Whether to allow navigation using this extension to different versions

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -83,199 +83,186 @@ export const REPOS = {
 }
 
 export interface RepoType {
-    url: string
-    repoFormat?: string
-    repoID: string
-    titleSelector?: string
-    versionSelector?: string
-    versionPath?: string
-    appendVersionPath?: string
-    pathRegex?: RegExp
-    versionDomPath?: string
+    url: string                 // URL to the repo without package or version
+    repoFormat: string          // Repo Format
+    repoID: string              // Unique ID for this Repo
+    titleSelector: string       // DOM selector to find the Package Title - used to annotate the page
+    // versionSelector?: string
+    versionPath: string         // URL format with placeholders
+    // appendVersionPath?: string
+    pathRegex: RegExp           // Regex for parsing URL
+    versionDomPath: string      // DOM selector to find component version on the page (not always in the URL)
+    supportsVersionNavigation: boolean // Whether to allow navigation using this extension to different versions
 }
 
 export const REPO_TYPES: RepoType[] = [
     {
-        repoID: REPOS.alpineLinux,
         url: 'https://pkgs.alpinelinux.org/package/',
         repoFormat: FORMATS.alpine,
+        repoID: REPOS.alpineLinux,       
         titleSelector: 'th.header ~ td',
         versionPath: '',
-        appendVersionPath: '',
         pathRegex:
             /^(?<releaseName>[^/]*)\/(?<releaseFeed>[^/]*)\/(?<architecture>[^/]*)\/(?<artifactId>[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: '#package > tbody > tr:nth-child(2) > td',
+        supportsVersionNavigation: false
     },
-    // {
-    //     url: 'https://clojars.org/',
-    //     repoFormat: FORMATS.clojars,
-    //     repoID: REPOS.clojarsOrg,
-    //     titleSelector: '#jar-title > h1 > a',
-    //     versionPath: '',
-    //     appendVersionPath: '/versions/{version}',
-    // },
     {
         url: 'https://cocoapods.org/pods/',
         repoFormat: FORMATS.cocoapods,
         repoID: REPOS.cocoaPodsOrg,
         titleSelector: 'h1',
-        versionPath: '',
-        appendVersionPath: '',
+        versionPath: '{artifactId}',
         pathRegex: /^(?<artifactId>[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: 'h1 > span',
+        supportsVersionNavigation: false
     },
     {
         url: 'https://conan.io/center/recipes/',
         repoFormat: FORMATS.conan,
         repoID: REPOS.conanIo,
         titleSelector: 'h1',
-        versionPath: '',
-        appendVersionPath: '',
+        versionPath: '{artifactId}?version={version}',
         pathRegex: /^(?<artifactId>[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: 'h1',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://cran.r-project.org/',
         repoFormat: FORMATS.cran,
         repoID: REPOS.cranRProject,
-        titleSelector: 'h2', //"h2.title",?
-        versionPath: '',
-        appendVersionPath: '',
+        titleSelector: 'h2',
+        versionPath: 'web/packages/{artifactId}/index.html',
         pathRegex: /^web\/packages\/(?<artifactId>[^/]*)\/index\.html(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: 'table tr:nth-child(1) td:nth-child(2)',
+        supportsVersionNavigation: false
     },
     {
-        repoID: REPOS.cratesIo,
         url: 'https://crates.io/crates/',
         repoFormat: FORMATS.cargo,
+        repoID: REPOS.cratesIo,       
         titleSelector: "div[class*='heading'] h1",
-        versionPath: '{url}/{packagename}/{versionNumber}', // https://crates.io/crates/claxon/0.4.0
-        appendVersionPath: '/{versionNumber}',
+        versionPath: '{artifactId}/{version}', // https://crates.io/crates/claxon/0.4.0
+        pathRegex: /^(?<artifactId>[^/#?]*)\/(?<version>v[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionDomPath: 'h1 small',
+        supportsVersionNavigation: true
     },
     {
-        url: 'https://pkg.go.dev/',
         //old gocenter path ->// https://search.gocenter.io/github.com~2Fgo-gitea~2Fgitea/info?version=v1.5.1
         //https://pkg.go.dev/github.com/etcd-io/etcd
         //https://pkg.go.dev/github.com/etcd-io/etcd@v3.3.25+incompatible
+        url: 'https://pkg.go.dev/',
         repoFormat: FORMATS.golang,
         repoID: REPOS.pkgGoDev,
-        titleSelector:
-            'body > main > header > div.go-Main-headerContent > div.go-Main-headerTitle.js-stickyHeader > h1',
-        versionPath: '{url}/{packagename}/@{versionNumber}',
-        appendVersionPath: '@{versionNumber}',
+        titleSelector: 'body > main > header > div.go-Main-headerContent > div.go-Main-headerTitle.js-stickyHeader > h1',
+        versionPath: '{groupAndArtifactId}/@{version}',
         pathRegex:
             /^(?<groupId>.+)\/(?<artifactId>[^/]*)\/(?<version>v[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionDomPath: '',
+        supportsVersionNavigation: false
     },
     {
         url: 'https://central.sonatype.com/artifact/',
         repoFormat: FORMATS.maven,
         repoID: REPOS.centralSonatypeCom,
         titleSelector: 'h1',
-        versionPath: '{url}/{groupid}/{artifactid}/{versionNumber}/{extension}',
-        appendVersionPath: '',
+        versionPath: '{groupId}/{artifactId}/{version}',
         pathRegex:
             /^(?<groupId>[^/]*)\/(?<artifactId>[^/]*)\/(?<version>[^/#?]*)(\/[^#?]*)?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionDomPath: '',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://repo.maven.apache.org/maven2/',
         repoFormat: FORMATS.maven,
         repoID: REPOS.repoMavenApacheOrg,
         titleSelector: 'h1',
-        versionPath: '{url}/{groupid}/{artifactid}/{versionNumber}',
-        appendVersionPath: '',
+        versionPath: '{groupId}/{artifactId}/{version}',
         pathRegex:
             /^(?<groupArtifactId>([^#?&]*)+)\/(?<version>[^/#&?]+)?\/?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?/,
+        versionDomPath: '',
+        supportsVersionNavigation: false
     },
     {
         url: 'https://repo1.maven.org/maven2/',
         repoFormat: FORMATS.maven,
         repoID: REPOS.repo1MavenOrg,
         titleSelector: 'h1',
-        versionPath: '{url}/{groupid}/{artifactid}/{versionNumber}',
-        appendVersionPath: '',
+        versionPath: '{groupId}/{artifactId}/{version}',
         pathRegex:
             /^(?<groupArtifactId>([^#?&]*)+)\/(?<version>[^/#&?]+)\/?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?/,
+        versionDomPath: '',
+        supportsVersionNavigation: false
     },
     {
         url: 'https://search.maven.org/artifact/',
         repoFormat: FORMATS.maven,
         repoID: REPOS.searchMavenOrg,
         titleSelector: '.artifact-title',
-        versionPath: '{url}/{groupid}/{artifactid}/{versionNumber}/{extension}',
-        appendVersionPath: '',
+        versionPath: '{groupId}/{artifactId}/{version}/{extension}',
         pathRegex:
             /^(?<groupId>[^/]*)\/(?<artifactId>[^/]*)(\/(?<version>[^/#?]*)\/(?<type>[^?#]*))?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionDomPath: '',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://mvnrepository.com/artifact/',
         repoFormat: FORMATS.maven,
         repoID: REPOS.mvnRepositoryCom,
         titleSelector: 'h2.im-title',
-        versionPath: '{url}/{groupid}/{artifactid}/{versionNumber}',
-        appendVersionPath: '',
-        pathRegex:
-            /^(?<groupId>[^/]*)\/(?<artifactId>[^/]*)\/(?<version>[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionPath: '{groupId}/{artifactId}/{version}',
+        pathRegex: /^(?<groupId>[^/]*)\/(?<artifactId>[^/]*)\/(?<version>[^/#?]*)(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionDomPath: '',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://www.npmjs.com/package/',
         repoFormat: FORMATS.npm,
         repoID: REPOS.npmJs,
         titleSelector: '#top > div > h1 > span',
-        versionPath: '{url}/{packagename}/v/{versionNumber}',
-        appendVersionPath: '/v/{versionNumber}',
-        pathRegex:
-            /^((?<groupId>@[^/]*)\/)?(?<artifactId>[^/?#]*)(\/v\/(?<version>[^?#]*))?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionPath: '{groupAndArtifactId}/v/{version}',
+        pathRegex: /^((?<groupId>@[^/]*)\/)?(?<artifactId>[^/?#]*)(\/v\/(?<version>[^?#]*))?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: '#top > div > span',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://www.nuget.org/packages/',
         repoFormat: FORMATS.nuget,
         repoID: REPOS.nugetOrg,
         titleSelector: '.package-title > h1',
-        versionSelector: 'span.version-title',
-        versionPath: '{url}/{packagename}/{versionNumber}',
-        appendVersionPath: '/{versionNumber}',
+        versionPath: '{artifactId}/{version}',
         pathRegex: /^(?<artifactId>[^/?#]*)(\/(?<version>[^/?#]*)\/?)?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: 'span.version-title',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://packagist.org/packages/',
         repoFormat: FORMATS.composer,
         repoID: REPOS.packagistOrg,
         titleSelector: 'h2.title',
-        versionPath: '{url}/{packagename}#{versionNumber}',
-        appendVersionPath: '#{versionNumber}',
+        versionPath: '{groupAndArtifactId}#{version}',
         pathRegex: /^(?<groupId>[^/]*)\/(?<artifactId>[^/?#]*)(\?(?<query>([^#]*)))?(#(?<version>(.*)))?$/,
         versionDomPath: '#view-package-page .versions-section .title .version-number',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://pypi.org/project/',
         repoFormat: FORMATS.pypi,
         repoID: REPOS.pypiOrg,
         titleSelector: 'h1.package-header__name',
-        versionPath: '{url}/{packagename}/{versionNumber}',
-        appendVersionPath: '{versionNumber}',
+        versionPath: '{artifactId}/{version}',
         pathRegex: /^(?<artifactId>[^/?#]*)\/((?<version>[^?#]*)\/)?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: '#content > div.banner > div > div.package-header__left > h1',
+        supportsVersionNavigation: true
     },
     {
         url: 'https://rubygems.org/gems/',
         repoFormat: FORMATS.gem,
         repoID: REPOS.rubyGemsOrg,
         titleSelector: 'h1.t-display',
-        versionSelector: 'body > main > div > h1 > i',
-        versionPath: '{url}/{packagename}/versions/{versionNumber}',
-        appendVersionPath: '/versions/{versionNumber}',
-        pathRegex:
-            /^(?<artifactId>[^/?#]*)(\/versions\/(?<version>[^?#-]*)-?(?<platform>[^?#]*))?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
+        versionPath: '{artifactId}/versions/{version}',
+        pathRegex: /^(?<artifactId>[^/?#]*)(\/versions\/(?<version>[^?#-]*)-?(?<platform>[^?#]*))?(\?(?<query>([^#]*)))?(#(?<fragment>(.*)))?$/,
         versionDomPath: '.page__subheading',
-    },
-    // {
-    //     url: '/#browse/browse:',
-    //     repoID: REPOS.nexusRepository,
-    //     titleSelector: "div[id*='-coreui-component-componentinfo-'",
-    //     versionPath: '',
-    //     dataSource: DATA_SOURCES.NEXUSIQ,
-    //     appendVersionPath: '',
-    // },
+        supportsVersionNavigation: true
+    }
 ]

--- a/src/utils/Helpers.test.ts
+++ b/src/utils/Helpers.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it, test } from '@jest/globals'
+import { getNewSelectedVersionUrl } from './Helpers'
+import { PackageURL } from 'packageurl-js'
+
+
+describe('Utils: Helpers: getNewSelectedVersionUrl', () => {
+
+    it.each([
+        // Conan
+        // TBC
+        {
+            registry: 'central.sonatype.com',
+            registryUrl: 'https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-core', 
+            currentPurl: 'pkg:maven/org.apache.logging.log4j/log4j-core@2.12.1', 
+            newVersion: '3.0.0-alpha1'
+        },
+        {
+            registry: 'crates.io',
+            registryUrl: 'https://crates.io/crates/claxon',
+            currentPurl: 'pkg:cargo/claxon@0.4.3',
+            newVersion: '3.2.1'
+        },
+        {
+            registry: 'mvnrepository.com',
+            registryUrl: 'https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core',
+            currentPurl: 'pkg:maven/org.apache.logging.log4j/log4j-core@2.14.0', 
+            newVersion: '2.15.0'
+        },
+        {
+            registry: 'npmjs.com',
+            registryUrl: 'https://www.npmjs.com/package/lodash',
+            currentPurl: 'pkg:npm/lodash@4.17.21',
+            newVersion: '4.17.22',
+            expectedUrl: 'https://www.npmjs.com/package/lodash/v/4.17.22'
+        },
+        {
+            registry: 'packagist.org',
+            registryUrl: 'https://packagist.org/packages/cyclonedx/cyclonedx-library',
+            currentPurl: 'pkg:composer/cyclonedx/cyclonedx-library@2.1.0',
+            newVersion: '2.2.2',
+            expectedUrl: 'https://packagist.org/packages/cyclonedx/cyclonedx-library#2.2.2'
+        },
+        {
+            registry: 'pypi.org',
+            registryUrl: 'https://pypi.org/project/PyJWT',
+            currentPurl: 'pkg:pypi/pyjwt@1.7.1',
+            newVersion: '1.7.5',
+            expectedUrl: 'https://pypi.org/project/pyjwt/1.7.5'
+        },
+        {
+            registry: 'search.maven.org',
+            registryUrl: 'https://search.maven.org/artifact/org.apache.struts/struts2-core',
+            currentPurl: 'pkg:maven/org.apache.struts/struts2-core@2.3.30?extension=jar',
+            newVersion: '2.3.31',
+            expectedUrl: 'https://search.maven.org/artifact/org.apache.struts/struts2-core/2.3.31/jar'
+        },
+        {
+            registry: 'www.nuget.org',
+            registryUrl: 'https://www.nuget.org/packages/moq',
+            currentPurl: 'pkg:nuget/moq@4.20.1',
+            newVersion: '4.20.2'
+        }
+    ])('$registry', ({registryUrl, currentPurl, newVersion, expectedUrl}) => {
+        const registry = new URL(registryUrl)
+        const currentPackageUrl = PackageURL.fromString(currentPurl)
+
+        // Test return same URL
+        const newUrl = getNewSelectedVersionUrl(registry, currentPackageUrl)
+        expect(newUrl).toBeDefined()
+        expect(newUrl).toEqual(registry)
+
+        // Test with new version
+        const newVersionUrl = getNewSelectedVersionUrl(registry, currentPackageUrl, newVersion)
+        let expectedNewUrl = new URL(`${registryUrl}/${newVersion}`)
+        if (expectedUrl !== undefined) {
+            expectedNewUrl = new URL(expectedUrl)
+        }
+        expect(newVersionUrl).toBeDefined()
+        expect(newVersionUrl.toString()).toEqual(expectedNewUrl.toString())
+    })
+})

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -33,6 +33,16 @@ function stripTrailingSlash(url: string): string {
     return url.endsWith('/') ? url.slice(0, -1) : url
 }
 
+/**
+ * Attempts to calculate the URL to the newVersion (if supplied). Returns the currentUrl 
+ * where either no newVersion is supplied or the OSS Registry in question is defined as 
+ * not supporting navigation to specific versions.
+ * 
+ * @param currentUrl 
+ * @param currentPurl 
+ * @param newVersion 
+ * @returns
+ */
 function getNewSelectedVersionUrl(currentUrl: URL, currentPurl: PackageURL, newVersion?: string): URL {
     let nextUrl = currentUrl.toString()
     if (newVersion !== undefined) {

--- a/src/utils/Helpers.ts
+++ b/src/utils/Helpers.ts
@@ -14,13 +14,8 @@
  * limitations under the License.
  */
 
-// import crypto from 'crypto'
 import { PackageURL } from 'packageurl-js'
-import { logger, LogLevel } from '../logger/Logger'
 import { findPublicOssRepoType } from './UrlParsing'
-
-// eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-explicit-any
-const _browser: any = chrome ? chrome : browser
 
 function ensure<T>(argument: T | undefined | null, message = 'This value was promised to be there.'): T {
     if (argument === undefined || argument === null) {
@@ -66,25 +61,4 @@ function getNewSelectedVersionUrl(currentUrl: URL, currentPurl: PackageURL, newV
     return new URL(nextUrl)
 }
 
-function getNewUrlandGo(currentTab: chrome.tabs.Tab | browser.tabs.Tab, currentPurlVersion: string, version: string) {
-    const currentTabUrl = currentTab.url
-    // const currentPurlVersion = popupContext.currentPurl?.version
-
-    logger.logMessage(`Remediation Details: Replacing URL with ${version}`, LogLevel.DEBUG)
-    if (currentPurlVersion !== undefined && currentTabUrl !== undefined) {
-        const currentVersion = new RegExp(currentPurlVersion as string)
-        const newUrl = currentTabUrl?.toString().replace(currentVersion, version)
-        logger.logMessage(`Remediation Details: Generated new URL ${newUrl}`, LogLevel.DEBUG)
-        _browser.tabs.update({
-            url: newUrl,
-        })
-        window.close()
-    } else {
-        logger.logMessage(
-            `Remediation Details: currentTabURL or currentPul are undefined when trying to replace with ${version}`,
-            LogLevel.ERROR
-        )
-    }
-}
-
-export { ensure, stripHtmlComments, getNewSelectedVersionUrl, getNewUrlandGo, stripTrailingSlash }
+export { ensure, stripHtmlComments, getNewSelectedVersionUrl, stripTrailingSlash }

--- a/src/utils/PageParsing/Alpine.ts
+++ b/src/utils/PageParsing/Alpine.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import $ from 'cash-dom'
 import { PackageURL } from 'packageurl-js'
 import { generatePackageURL } from './PurlUtils'
@@ -22,13 +23,11 @@ const parseAlpine = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.alpineLinux)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
-                const version = $(repoType.versionDomPath).text().trim()
-                return generatePackageURL(FORMATS.alpine, encodeURIComponent(pathResult.groups.artifactId), version)
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
+            const version = $(repoType.versionDomPath).text().trim()
+            return generatePackageURL(FORMATS.alpine, encodeURIComponent(pathResult.groups.artifactId), version)
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/CRAN.ts
+++ b/src/utils/PageParsing/CRAN.ts
@@ -18,21 +18,16 @@ import $ from 'cash-dom'
 import { PackageURL } from 'packageurl-js'
 import { FORMATS, REPOS, REPO_TYPES } from '../Constants'
 import { generatePackageURL } from './PurlUtils'
-/*
-  https://cran.r-project.org/
-  https://cran.r-project.org/web/packages/latte/index.html
-*/
+
 const parseCRAN = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.cranRProject)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
-                const version = $(repoType.versionDomPath).first().text().trim()
-                return generatePackageURL(FORMATS.cran, encodeURIComponent(pathResult.groups.artifactId), version)
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
+            const version = $(repoType.versionDomPath).first().text().trim()
+            return generatePackageURL(FORMATS.cran, encodeURIComponent(pathResult.groups.artifactId), version)
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/CentralSonatypeCom.ts
+++ b/src/utils/PageParsing/CentralSonatypeCom.ts
@@ -22,7 +22,6 @@ import { generatePackageURLComplete } from './PurlUtils'
 const PACKAGING_FORMATS_NOT_JAR = new Set<string>(['aar', 'ear', 'war'])
 const POM_PACKAGING_REGEX = /<packaging>(?<packaging>(.*))<\/packaging>/
 
-//pkg:type/namespace/name@version?qualifiers#subpath
 const parseCentralSonatypeCom = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.centralSonatypeCom)
     console.debug('*** REPO TYPE: ', repoType)
@@ -43,19 +42,16 @@ const parseCentralSonatypeCom = (url: string): PackageURL | undefined => {
             return purl
         }
         
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            
-            if (pathResult && pathResult.groups) {
-                return generatePackageURLComplete(
-                    FORMATS.maven,
-                    encodeURIComponent(pathResult.groups.artifactId),
-                    encodeURIComponent(pathResult.groups.version),
-                    encodeURIComponent(pathResult.groups.groupId),
-                    { type: type },
-                    undefined
-                )
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        if (pathResult && pathResult.groups) {
+            return generatePackageURLComplete(
+                FORMATS.maven,
+                encodeURIComponent(pathResult.groups.artifactId),
+                encodeURIComponent(pathResult.groups.version),
+                encodeURIComponent(pathResult.groups.groupId),
+                { type: type },
+                undefined
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/CocoaPods.ts
+++ b/src/utils/PageParsing/CocoaPods.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import $ from 'cash-dom'
 import { PackageURL } from 'packageurl-js'
 import { logger, LogLevel } from '../../logger/Logger'
@@ -23,12 +24,10 @@ export const parseCocoaPods = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.cocoaPodsOrg)
     logger.logMessage(`Parsing CocoaPods ${repoType?.repoID}`, LogLevel.DEBUG)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
-                const version = $(repoType.versionDomPath).first().text().trim()
-                return generatePackageURL(FORMATS.cocoapods, encodeURIComponent(pathResult.groups.artifactId), version)
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
+            const version = $(repoType.versionDomPath).first().text().trim()
+            return generatePackageURL(FORMATS.cocoapods, encodeURIComponent(pathResult.groups.artifactId), version)
         }
     } else {
         logger.logMessage('Unable to determine REPO TYPE.', LogLevel.INFO)

--- a/src/utils/PageParsing/ConanIo.ts
+++ b/src/utils/PageParsing/ConanIo.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import $ from 'cash-dom'
 import { PackageURL } from 'packageurl-js'
 import { logger, LogLevel } from '../../logger/Logger'
@@ -23,12 +24,10 @@ export const parseConanIo = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.conanIo)
     logger.logMessage(`Parsing ConanIo ${repoType?.repoID}`, LogLevel.DEBUG)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
-                const version = $(repoType.versionDomPath).text().trim().split('/')[1]
-                return generatePackageURL(FORMATS.conan, encodeURIComponent(pathResult.groups.artifactId), version)
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        if (pathResult && pathResult.groups && repoType.versionDomPath !== undefined) {
+            const version = $(repoType.versionDomPath).text().trim().split('/')[1]
+            return generatePackageURL(FORMATS.conan, encodeURIComponent(pathResult.groups.artifactId), version)
         }
     } else {
         logger.logMessage('Unable to determine REPO TYPE.', LogLevel.INFO)

--- a/src/utils/PageParsing/MVNRepository.ts
+++ b/src/utils/PageParsing/MVNRepository.ts
@@ -13,31 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//https://mvnrepository.com/artifact/org.apache.struts/struts2-core/2.2.3
-//"purl": "pkg:maven/com.mycompany.myproduct/artifact-name@2.1.7",
+
 import { PackageURL } from 'packageurl-js'
 import { FORMATS, REPOS, REPO_TYPES } from '../Constants'
 import { generatePackageURLComplete } from './PurlUtils'
 
-//pkg:type/namespace/name@version?qualifiers#subpath
-//Sonatype expects: "packageUrl": "pkg:maven/org.yaml/snakeyaml@1.17?type=jar"
 const parseMVNRepository = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.mvnRepositoryCom)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                return generatePackageURLComplete(
-                    FORMATS.maven,
-                    encodeURIComponent(pathResult.groups.artifactId),
-                    encodeURIComponent(pathResult.groups.version),
-                    encodeURIComponent(pathResult.groups.groupId),
-                    { type: 'jar' },
-                    undefined
-                )
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            return generatePackageURLComplete(
+                FORMATS.maven,
+                encodeURIComponent(pathResult.groups.artifactId),
+                encodeURIComponent(pathResult.groups.version),
+                encodeURIComponent(pathResult.groups.groupId),
+                { type: 'jar' },
+                undefined
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/NPM.ts
+++ b/src/utils/PageParsing/NPM.ts
@@ -24,20 +24,18 @@ const parseNPM = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.npmJs)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                console.debug(`"${stripHtmlComments($(repoType.versionDomPath).first().text())}"`)
-                const pageVersion = stripHtmlComments($(repoType.versionDomPath).first().text()).split('•')[0].trim()
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            console.debug(`"${stripHtmlComments($(repoType.versionDomPath).first().text())}"`)
+            const pageVersion = stripHtmlComments($(repoType.versionDomPath).first().text()).split('•')[0].trim()
 
-                return generatePackageURLWithNamespace(
-                    FORMATS.npm,
-                    pathResult.groups.artifactId,
-                    pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
-                    pathResult.groups.groupId
-                )
-            }
+            return generatePackageURLWithNamespace(
+                FORMATS.npm,
+                pathResult.groups.artifactId,
+                pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
+                pathResult.groups.groupId
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/NexusRepositoryPageParsing.test.ts
+++ b/src/utils/PageParsing/NexusRepositoryPageParsing.test.ts
@@ -16,15 +16,19 @@
 import { describe, expect, test } from '@jest/globals'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-import { FORMATS } from '../Constants'
+import { FORMATS, RepoType } from '../Constants'
 import { getArtifactDetailsFromNxrmDom } from './NexusRepositoryPageParsing'
-import exp from 'constants'
 
 describe('NXRM3 Page Parsing', () => {
-    const repoType = {
+    const repoType: RepoType = {
         url: 'https://repo.tld/',
         repoFormat: FORMATS.NXRM,
         repoID: 'NXRM-https://repo.tld/',
+        titleSelector: '',
+        versionPath: '',
+        pathRegex: /^$/,
+        versionDomPath: '',
+        supportsVersionNavigation: false
     }
 
     /**

--- a/src/utils/PageParsing/Nuget.ts
+++ b/src/utils/PageParsing/Nuget.ts
@@ -23,20 +23,18 @@ const parseNuget = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.nugetOrg)
     console.debug('*** REPO TYPE + URL: ', repoType, url)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                const pageVersion = $(repoType.versionDomPath).text().trim()
-                console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
-                return generatePackageURL(
-                    FORMATS.nuget,
-                    encodeURIComponent(pathResult.groups.artifactId),
-                    encodeURIComponent(
-                        pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion
-                    )
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            const pageVersion = $(repoType.versionDomPath).text().trim()
+            console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
+            return generatePackageURL(
+                FORMATS.nuget,
+                encodeURIComponent(pathResult.groups.artifactId),
+                encodeURIComponent(
+                    pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion
                 )
-            }
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/Packagist.ts
+++ b/src/utils/PageParsing/Packagist.ts
@@ -23,20 +23,18 @@ const parsePackagist = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.packagistOrg)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                console.debug($(repoType.versionDomPath))
-                const pageVersion = $(repoType.versionDomPath).text().trim()
-                console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
-                return generatePackageURLWithNamespace(
-                    FORMATS.composer,
-                    encodeURIComponent(pathResult.groups.artifactId),
-                    pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
-                    encodeURIComponent(pathResult.groups.groupId)
-                )
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            console.debug($(repoType.versionDomPath))
+            const pageVersion = $(repoType.versionDomPath).text().trim()
+            console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
+            return generatePackageURLWithNamespace(
+                FORMATS.composer,
+                encodeURIComponent(pathResult.groups.artifactId),
+                pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
+                encodeURIComponent(pathResult.groups.groupId)
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/PyPI.ts
+++ b/src/utils/PageParsing/PyPI.ts
@@ -25,25 +25,23 @@ const parsePyPIURL = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.pypiOrg)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                console.debug($(repoType.versionDomPath))
-                const pageVersion = $(repoType.versionDomPath).text().trim().split(' ')[1]
-                console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
-                const firstDistributionFilename = $(PYPI_EXTENSION_SELECTOR).first().text().trim()
-                let extension = PYPI_DEFAULT_EXTENSION
-                if (firstDistributionFilename !== undefined && !firstDistributionFilename.endsWith(PYPI_DEFAULT_EXTENSION)) {
-                    extension = firstDistributionFilename.split('.').pop() as string
-                }
-                return generatePackageURL(
-                    FORMATS.pypi,
-                    pathResult.groups.artifactId,
-                    pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
-                    { extension: extension }
-                )
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            console.debug($(repoType.versionDomPath))
+            const pageVersion = $(repoType.versionDomPath).text().trim().split(' ')[1]
+            console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
+            const firstDistributionFilename = $(PYPI_EXTENSION_SELECTOR).first().text().trim()
+            let extension = PYPI_DEFAULT_EXTENSION
+            if (firstDistributionFilename !== undefined && !firstDistributionFilename.endsWith(PYPI_DEFAULT_EXTENSION)) {
+                extension = firstDistributionFilename.split('.').pop() as string
             }
+            return generatePackageURL(
+                FORMATS.pypi,
+                pathResult.groups.artifactId,
+                pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
+                { extension: extension }
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/RepoMavenApacheOrg.ts
+++ b/src/utils/PageParsing/RepoMavenApacheOrg.ts
@@ -20,21 +20,19 @@ import { generatePackageURLComplete } from './PurlUtils'
 import { FORMATS, REPOS, REPO_TYPES, RepoType } from '../Constants'
 
 function parseMavenOrg(repoType: RepoType, url: string): PackageURL | undefined {
-    if (repoType.pathRegex) {
-        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-        if (pathResult && pathResult.groups) {
-            const gaParts = pathResult.groups.groupArtifactId.trim().split('/')
-            const artifactId = gaParts.pop()
-            const groupId = gaParts.join('.')
-            return generatePackageURLComplete(
-                FORMATS.maven,
-                encodeURIComponent(artifactId as string),
-                encodeURIComponent(pathResult.groups.version),
-                encodeURIComponent(groupId),
-                { type: 'jar' },
-                undefined
-            )
-        }
+    const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+    if (pathResult && pathResult.groups) {
+        const gaParts = pathResult.groups.groupArtifactId.trim().split('/')
+        const artifactId = gaParts.pop()
+        const groupId = gaParts.join('.')
+        return generatePackageURLComplete(
+            FORMATS.maven,
+            encodeURIComponent(artifactId as string),
+            encodeURIComponent(pathResult.groups.version),
+            encodeURIComponent(groupId),
+            { type: 'jar' },
+            undefined
+        )
     }
 
     return undefined

--- a/src/utils/PageParsing/RubyGems.ts
+++ b/src/utils/PageParsing/RubyGems.ts
@@ -23,20 +23,18 @@ const parseRuby = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.rubyGemsOrg)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                console.debug($(repoType.versionDomPath))
-                const pageVersion = $(repoType.versionDomPath).text().trim()
-                console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
-                return generatePackageURL(
-                    FORMATS.gem,
-                    pathResult.groups.artifactId,
-                    pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
-                    pathResult.groups.platform !== undefined ? { platform: pathResult.groups.platform } : undefined
-                )
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            console.debug($(repoType.versionDomPath))
+            const pageVersion = $(repoType.versionDomPath).text().trim()
+            console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
+            return generatePackageURL(
+                FORMATS.gem,
+                pathResult.groups.artifactId,
+                pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
+                pathResult.groups.platform !== undefined ? { platform: pathResult.groups.platform } : undefined
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/PageParsing/SearchMavenOrg.ts
+++ b/src/utils/PageParsing/SearchMavenOrg.ts
@@ -19,30 +19,26 @@ import { PackageURL } from 'packageurl-js'
 import { FORMATS, REPOS, REPO_TYPES } from '../Constants'
 import { generatePackageURLComplete } from './PurlUtils'
 
-// TODO: Handle the bundle extension
-//pkg:type/namespace/name@version?qualifiers#subpath
 const parseSearchMavenOrg = (url: string): PackageURL | undefined => {
     const repoType = REPO_TYPES.find((e) => e.repoID == REPOS.searchMavenOrg)
     console.debug('*** REPO TYPE: ', repoType)
     if (repoType) {
-        if (repoType.pathRegex) {
-            const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
-            console.debug(pathResult?.groups)
-            if (pathResult && pathResult.groups) {
-                console.debug($(repoType.versionDomPath))
-                const pageVersion = $(repoType.versionDomPath).text().trim()
-                console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
-                return generatePackageURLComplete(
-                    FORMATS.maven,
-                    encodeURIComponent(pathResult.groups.artifactId),
-                    pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
-                    encodeURIComponent(pathResult.groups.groupId),
-                    {
-                        type: pathResult.groups.type !== undefined ? pathResult.groups.type : 'jar',
-                    },
-                    undefined
-                )
-            }
+        const pathResult = repoType.pathRegex.exec(url.replace(repoType.url, ''))
+        console.debug(pathResult?.groups)
+        if (pathResult && pathResult.groups) {
+            console.debug($(repoType.versionDomPath))
+            const pageVersion = $(repoType.versionDomPath).text().trim()
+            console.debug(`URL Version: ${pathResult.groups.version}, Page Version: ${pageVersion}`)
+            return generatePackageURLComplete(
+                FORMATS.maven,
+                encodeURIComponent(pathResult.groups.artifactId),
+                pathResult.groups.version !== undefined ? pathResult.groups.version : pageVersion,
+                encodeURIComponent(pathResult.groups.groupId),
+                {
+                    type: pathResult.groups.type !== undefined ? pathResult.groups.type : 'jar',
+                },
+                undefined
+            )
         }
     } else {
         console.error('Unable to determine REPO TYPE.')

--- a/src/utils/UrlParsing.test.ts
+++ b/src/utils/UrlParsing.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, test } from '@jest/globals'
+import { findPublicOssRepoType } from './UrlParsing'
+import { REPOS, REPO_TYPES } from './Constants'
+
+
+describe('Utils: UrlParsing: findPublicOssRepoType', () => {
+   
+    test('VALID: alpinelinux.org no version', () => {
+        const repoType = findPublicOssRepoType('https://pkgs.alpinelinux.org/package/edge/main/x86_64/curl')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.alpineLinux))
+    })
+
+    test('VALID: cocoapods.org no version', () => {
+        const repoType = findPublicOssRepoType('https://cocoapods.org/pods/Log4swift')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.cocoaPodsOrg))
+    })
+
+    test('VALID: cran.r-project.org no version', () => {
+        const repoType = findPublicOssRepoType('https://cran.r-project.org/web/packages/xgboost/index.html')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.cranRProject))
+    })
+
+    test('VALID: crates.io no version', () => {
+        const repoType = findPublicOssRepoType('https://crates.io/crates/claxon')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.cratesIo))
+    })
+
+    test('VALID: crates.io with version', () => {
+        const repoType = findPublicOssRepoType('https://crates.io/crates/claxon/0.4.3')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.cratesIo))
+    })
+
+    test('VALID: central.sonatype.com no version', () => {
+        const repoType = findPublicOssRepoType('https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-core')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.centralSonatypeCom))
+    })
+
+    test('VALID: central.sonatype.com with version', () => {
+        const repoType = findPublicOssRepoType('https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j-core/2.13.2')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.centralSonatypeCom))
+    })
+
+    test('VALID: repo.maven.apache.org no version', () => {
+        const repoType = findPublicOssRepoType('https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.repoMavenApacheOrg))
+    })
+
+    test('VALID: repo.maven.apache.org with version', () => {
+        const repoType = findPublicOssRepoType('https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.13.1/')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.repoMavenApacheOrg))
+    })
+
+    test('VALID: repo1.maven.org no version', () => {
+        const repoType = findPublicOssRepoType('https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.repo1MavenOrg))
+    })
+
+    test('VALID: repo1.maven.org with version', () => {
+        const repoType = findPublicOssRepoType('https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.13.1/')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.repo1MavenOrg))
+    })
+
+    test('VALID: search.maven.org no version', () => {
+        const repoType = findPublicOssRepoType('https://search.maven.org/artifact/org.apache.logging.log4j/log4j-core')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.searchMavenOrg))
+    })
+
+    test('VALID: search.maven.org with version', () => {
+        const repoType = findPublicOssRepoType('https://search.maven.org/artifact/org.apache.logging.log4j/log4j-core/2.12.2/jar')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.searchMavenOrg))
+    })
+
+    test('VALID: mvnrepository.com no version', () => {
+        const repoType = findPublicOssRepoType('https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.mvnRepositoryCom))
+    })
+
+    test('VALID: mvnrepository.com with version', () => {
+        const repoType = findPublicOssRepoType('https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core/2.13.1')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.mvnRepositoryCom))
+    })
+
+    test('VALID: npmjs.org no version', () => {
+        const repoType = findPublicOssRepoType('https://www.npmjs.com/package/lodash')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.npmJs))
+    })
+
+    test('VALID: npmjs.org with version', () => {
+        const repoType = findPublicOssRepoType('https://www.npmjs.com/package/lodash/v/4.17.21')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.npmJs))
+    })
+
+    test('VALID: www.nuget.org no version', () => {
+        const repoType = findPublicOssRepoType('https://www.nuget.org/packages/Newtonsoft.Json')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.nugetOrg))
+    })
+
+    test('VALID: www.nuget.org with version', () => {
+        const repoType = findPublicOssRepoType('https://www.nuget.org/packages/Newtonsoft.Json/13.0.3')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.nugetOrg))
+    })
+
+    test('VALID: packagist.org no version', () => {
+        const repoType = findPublicOssRepoType('https://packagist.org/packages/cyclonedx/cyclonedx-library')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.packagistOrg))
+    })
+
+    test('VALID: packagist.org with version', () => {
+        const repoType = findPublicOssRepoType('https://packagist.org/packages/cyclonedx/cyclonedx-library#v2.3.0')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.packagistOrg))
+    })
+
+    test('VALID: pypi.org no version', () => {
+        const repoType = findPublicOssRepoType('https://pypi.org/project/PyJWT')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.pypiOrg))
+    })
+
+    test('VALID: pypi.org with version', () => {
+        const repoType = findPublicOssRepoType('https://pypi.org/project/PyJWT/1.7.1')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.pypiOrg))
+    })
+
+    test('VALID: rubygems.org no version', () => {
+        const repoType = findPublicOssRepoType('https://rubygems.org/gems/cyclonedx-ruby')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.rubyGemsOrg))
+    })
+
+    test('VALID: rubygems.org with version', () => {
+        const repoType = findPublicOssRepoType('https://rubygems.org/gems/cyclonedx-ruby/versions/1.1.0')
+        expect(repoType).toBeDefined()
+        expect(repoType).toBe(REPO_TYPES.find((e) => e.repoID == REPOS.rubyGemsOrg))
+    })
+
+})

--- a/src/utils/UrlParsing.ts
+++ b/src/utils/UrlParsing.ts
@@ -19,12 +19,24 @@ import { readExtensionConfiguration } from '../messages/SettingsMessages'
 import { MESSAGE_RESPONSE_STATUS } from '../types/Message'
 import { ExtensionConfiguration } from '../types/ExtensionConfiguration'
 
-const findRepoType = async (url: string): Promise<RepoType | undefined> => {
+const findPublicOssRepoType = (url: string): RepoType | undefined => {
     for (let i = 0; i < REPO_TYPES.length; i++) {
-        if (url.search(REPO_TYPES[i].url) >= 0) {
-            logger.logMessage(`Current URL ${url} matches ${REPO_TYPES[i].repoID}`, LogLevel.INFO)
-            return REPO_TYPES[i]
+        const repoType = REPO_TYPES[i]
+        if (url.search(repoType.url) >= 0) {
+            logger.logMessage(`Current URL ${url} matches ${repoType.repoID}`, LogLevel.INFO)
+            return repoType
+        } else {
+            logger.logMessage(`Current URL ${url} does not match ${repoType.repoID}`, LogLevel.TRACE)
         }
+    }
+    return undefined
+}
+
+const findRepoType = async (url: string): Promise<RepoType | undefined> => {
+    const repoType = findPublicOssRepoType(url)
+
+    if (repoType !== undefined) {
+        return repoType
     }
 
     return await findNxrmRepoType(url)
@@ -44,6 +56,10 @@ function findNxrmRepoType(url: string): Promise<RepoType | undefined> {
                             repoFormat: FORMATS.NXRM,
                             repoID: `NXRM-${nxrmHost.id}`,
                             titleSelector: "[id^='nx-coreui-component-componentassetinfo'][id$='header-title-textEl']",
+                            versionPath: '',
+                            pathRegex: /^$/,
+                            versionDomPath: '',
+                            supportsVersionNavigation: false
                         }
                     }
                 }
@@ -53,4 +69,4 @@ function findNxrmRepoType(url: string): Promise<RepoType | undefined> {
     })
 }
 
-export { findRepoType }
+export { findPublicOssRepoType, findRepoType }


### PR DESCRIPTION
Related to #106, the extension currently does not cater correctly for navigating to different component versions. Some public registries also do not have pages for all versions - so navigation is not actually possible.