### PR TITLE
fix: show only the suggested version when a golden version is available

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -390,5 +390,9 @@
     "GOLDEN_VERSION": {
         "message": "Golden Version",
         "description": "Golden Version (IQ 184+)"
+    },
+    "GOLDEN_VERSION_TOOLTIP": {
+        "message": "This is a safe-to-use version of the component, including its dependencies, with no resulting breaking changes, that can be used for upgrade to remediate the reported policy violation.",
+        "description": "Golden Version (IQ 184+) Tooltip from https://help.sonatype.com/en/golden-versions-and-prs.html#golden-versions"
     }
 }

--- a/public/css/pagestyle.css
+++ b/public/css/pagestyle.css
@@ -2,6 +2,11 @@
     max-width: unset !important;
 }
 
+.sonatype-iq-extension-golden {
+    padding-right: 15px !important;
+    vertical-align: bottom !important;;
+}
+
 .sonatype-iq-extension-vuln {
     padding-right: 15px !important;
     padding-left: 10px !important;

--- a/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/AllVersionsPage/AllVersionsDetails/AllVersionsDetails.tsx
@@ -19,6 +19,7 @@ import {
     NxLoadingSpinner,
     NxMeter,
     NxPolicyViolationIndicator,
+    NxSmallTag,
     NxThreatIndicator,
     ThreatLevelNumber,
 } from '@sonatype/react-shared-components'
@@ -220,7 +221,7 @@ function IqAllVersionDetails() {
 
                                                 <Tooltip title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
                                                     <span className='nx-pull-right'>
-                                                        {catalogDateDifference(version.catalogDate)}
+                                                        <small>{catalogDateDifference(version.catalogDate)}</small>
                                                     </span>
                                                 </Tooltip>
                                             </NxGrid.Header>
@@ -291,7 +292,7 @@ function IqAllVersionDetails() {
 
                                                 <Tooltip title={`Catalog Date: ${formatDate(version.catalogDate)}`}>
                                                     <span className='nx-pull-right'>
-                                                        {catalogDateDifference(version.catalogDate)}
+                                                        <small>{catalogDateDifference(version.catalogDate)}</small>
                                                     </span>
                                                 </Tooltip>
                                             </NxGrid.Header>

--- a/src/components/Popup/IQServer/RemediationPage/RemediationDetails/SuggestedVersionChange.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/RemediationDetails/SuggestedVersionChange.tsx
@@ -21,6 +21,7 @@ import { ExtensionPopupContext } from "../../../../../context/ExtensionPopupCont
 import { getNewSelectedVersionUrl } from "../../../../../utils/Helpers"
 import { NxList } from "@sonatype/react-shared-components"
 import { REMEDIATION_LABELS } from "../../../../../utils/Constants"
+import { Tooltip } from '@material-ui/core'
 
 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/no-explicit-any
 const _browser: any = chrome || browser
@@ -36,15 +37,19 @@ function SuggestedVersionLinkItemContent(props: SuggestedVersionChangeProps) {
             {props.suggestedVersion.isGolden != null && props.suggestedVersion.isGolden && (
                 <span>
                     <img
+                        style={{ paddingBottom: '3px', paddingRight: '7px', verticalAlign:'middle' }}
                         src='/images/golden-star.svg'
                         alt={_browser.i18n.getMessage('GOLDEN_VERSION')}
                         title={_browser.i18n.getMessage('GOLDEN_VERSION')}
                     />
                 </span>
             )}
-            <NxList.Text>
-                <small>{REMEDIATION_LABELS[props.suggestedVersion.type as string]}</small>
+            <Tooltip title={_browser.i18n.getMessage('GOLDEN_VERSION_TOOLTIP')}>
+            <NxList.Text
+                style={{ paddingRight: '0px' }}>
+                {REMEDIATION_LABELS[props.suggestedVersion.type as string]}
             </NxList.Text>
+            </Tooltip>
             <NxList.Subtext>
                 <strong>
                     {props.suggestedVersion.data?.component?.componentIdentifier?.coordinates
@@ -85,7 +90,9 @@ export default function SuggestedVersionChange(props: SuggestedVersionChangeProp
                 </NxList.LinkItem>
             )}
             {clickable !== true && (
-                <NxList.Item key="suggested-change">
+                <NxList.Item 
+                style={{ paddingRight: '0px !important' }}
+                    key="suggested-change">
                     <SuggestedVersionLinkItemContent suggestedVersion={props.suggestedVersion} />
                 </NxList.Item>
             )}

--- a/src/components/Popup/IQServer/RemediationPage/RemediationPage.tsx
+++ b/src/components/Popup/IQServer/RemediationPage/RemediationPage.tsx
@@ -42,8 +42,9 @@ function IqRemediationPage() {
                     )}
                     {versionChanges && versionChanges.length > 0 && <NxH3>
                         {_browser.i18n.getMessage('RECOMMENDED_VERSIONS')}
+                        <RemediationDetails />
                         </NxH3>}
-                    <RemediationDetails />
+                    
                 </section>
                 <section className='nx-grid-col nx-grid-col--67 nx-scrollable'>
                     <NxH3>


### PR DESCRIPTION
Fix #154 

Show only the suggested version when the golden version is available