### PR TITLE
fix: Detect licensed Sonatype Solutions correctly and consistently

### DIFF
--- a/src/common/configuration/types.ts
+++ b/src/common/configuration/types.ts
@@ -47,7 +47,7 @@ export interface SonatypeSolutionSupport {
     supportsLifecycleAlp: boolean
 }
 
-export const DEFAULT_SONATYPE_SOLUTION_SUPPORT = {
+export const DEFAULT_SONATYPE_SOLUTION_SUPPORT: SonatypeSolutionSupport = {
     supportsFirewall: false,
     supportsLifecycle: false,
     supportsLifecycleAlp: false,

--- a/src/options/components/iq-options-sub-page.tsx
+++ b/src/options/components/iq-options-sub-page.tsx
@@ -378,7 +378,7 @@ export default function IQOptionsSubPage(props: Readonly<IqServerOptionsPageInte
                             )}
                             {hasPermissions &&
                                 extensionConfigContext.iqAuthenticated === true &&
-                                extensionConfigContext.supportsLifecycle === true &&
+                                (extensionConfigContext.supportsLifecycle === true || extensionConfigContext.supportsFirewall) &&
                                 extensionConfigContext.iqApplications.length > 0 && (
                                     <React.Fragment>
                                         <p className='nx-p'>


### PR DESCRIPTION
Resolves #228 

There were gremlins in the state management and logic to determine which Sonatype Solutions are licensed. This PR resolves that.

Also ensures the new Solutions API is used for IQ >= 192 where it is available.