### PR TITLE
feat: Accept POM as a packaging format for component identity for central.sonatype.com 

### DIFF
--- a/src/common/page-parsing/central-sonatype-com.test.ts
+++ b/src/common/page-parsing/central-sonatype-com.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { describe, expect, it } from '@jest/globals'
-import { readFileSync } from 'fs'
+import { readFileSync } from 'node:fs'
 import { PackageURL } from 'packageurl-js'
-import { join } from 'path'
+import { join } from 'node:path'
 import { CentralSonatypeComPageParser } from './central-sonatype-com'
 import { CentralSonatypeComRepo } from '../repo-type/central-sonatype-com'
 
@@ -115,7 +115,7 @@ describe('central.sonatype.com Page Parsing', () => {
     ])('$name', async ({ url, testFile, expectedPurls }) => {
         if (testFile) {
             const html = readFileSync(join(__dirname, 'testdata', 'central.sonatype.com', testFile))
-            window.document.body.innerHTML = html.toString()
+            globalThis.document.body.innerHTML = html.toString()
         }
             
         const packageURLs = await parser.parsePage(url)

--- a/src/common/page-parsing/central-sonatype-com.test.ts
+++ b/src/common/page-parsing/central-sonatype-com.test.ts
@@ -77,7 +77,7 @@ describe('central.sonatype.com Page Parsing', () => {
             url: 'https://central.sonatype.com/artifact/org.apache.logging.log4j/log4j/3.0.0-alpha1',
             testFile: 'log4j-parent.html',
             expectedPurls: [
-                PackageURL.fromString('pkg:maven/org.apache.logging.log4j/log4j@3.0.0-alpha1?type=jar')
+                PackageURL.fromString('pkg:maven/org.apache.logging.log4j/log4j@3.0.0-alpha1?type=pom')
             ]
         },
         {

--- a/src/common/page-parsing/central-sonatype-com.ts
+++ b/src/common/page-parsing/central-sonatype-com.ts
@@ -18,7 +18,7 @@ import { PackageURL } from 'packageurl-js'
 import { generatePackageURLComplete } from '../purl-utils'
 import { BasePageParser } from './base'
 
-const PACKAGING_FORMATS_NOT_JAR = new Set<string>(['aar', 'ear', 'war'])
+const PACKAGING_FORMATS_NOT_JAR = new Set<string>(['aar', 'ear', 'war', 'pom'])
 const POM_PACKAGING_REGEX = /<packaging>(?<packaging>(.*))<\/packaging>/
 
 export class CentralSonatypeComPageParser extends BasePageParser {    


### PR DESCRIPTION
Resolves #68 - allowing Parent POMs to have identity determined correctly as many of these exist in Sonatype Data.